### PR TITLE
Add deprecation of namespace 'base' in favor of namespace 'numeric'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,19 @@
-install(FILES
+set(HEADERS
     Stats.hpp
     Histogram.hpp
     FitPolynom.hpp
     PlaneFitting.hpp
     MatchTemplate.hpp
-    DESTINATION include/numeric)
+    backwards/Histogram.hpp
+    backwards/PlaneFitting.hpp
+    backwards/Stats.hpp
+)
+rock_install_headers(${HEADERS})
 
 set(DEPS_PKGCONFIG "base-types")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/numeric.pc.in
                ${CMAKE_CURRENT_BINARY_DIR}/numeric.pc @ONLY)
+
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/numeric.pc
     DESTINATION lib/pkgconfig)

--- a/src/FitPolynom.hpp
+++ b/src/FitPolynom.hpp
@@ -1,6 +1,5 @@
-
-#ifndef __FITPOLYNOM_H 
-#define __FITPOLYNOM_H
+#ifndef __NUMERIC_FITPOLYNOM_HPP__
+#define __NUMERIC_FITPOLYNOM_HPP__
 
 #include <math.h>
 #include <vector>

--- a/src/Histogram.hpp
+++ b/src/Histogram.hpp
@@ -1,9 +1,9 @@
-#ifndef BASE_NUMERIC_HISTOGRAM__
-#define BASE_NUMERIC_HISTOGRAM__
+#ifndef __NUMERIC_HISTOGRAM_HPP__
+#define __NUMERIC_HISTOGRAM_HPP__
 
 #include <algorithm>
 
-namespace base
+namespace numeric
 {
 
 template <class T>
@@ -134,5 +134,9 @@ struct Histogram : public Buckets<size_t>
 };
 
 }
+
+#ifndef NUMERIC_DEPRECATE
+#include <numeric/backwards/Histogram.hpp>
+#endif
 
 #endif

--- a/src/MatchTemplate.hpp
+++ b/src/MatchTemplate.hpp
@@ -1,6 +1,5 @@
-
-#ifndef __MATCH_TEMPLATE
-#define __MATCH_TEMPLATE 
+#ifndef __NUMERIC_MATCH_TEMPLATE_HPP__
+#define __NUMERIC_MATCH_TEMPLATE_HPP__
 
 #include <vector>
 #include <limits>

--- a/src/PlaneFitting.hpp
+++ b/src/PlaneFitting.hpp
@@ -1,10 +1,10 @@
-#ifndef BASE_NUMERIC_PLANEFITTING_HPP__
-#define BASE_NUMERIC_PLANEFITTING_HPP__
+#ifndef __NUMERIC_PLANEFITTING_HPP__
+#define __NUMERIC_PLANEFITTING_HPP__
 
 #include <Eigen/Core>
 #include <Eigen/Cholesky>
 
-namespace base
+namespace numeric
 {
 
 /** 
@@ -176,5 +176,9 @@ public:
 };
 
 }
+
+#ifndef NUMERIC_DEPRECATE
+#include <numeric/backwards/PlaneFitting.hpp>
+#endif
 
 #endif

--- a/src/Stats.hpp
+++ b/src/Stats.hpp
@@ -1,10 +1,10 @@
-#ifndef BASE_STATS_HPP__
-#define BASE_STATS_HPP__
+#ifndef __NUMERIC_STATS_HPP__
+#define __NUMERIC_STATS_HPP__
 
 #include <Eigen/Core>
 #include <base/eigen.h>
 
-namespace base
+namespace numeric
 {
 
 template <class T>
@@ -144,8 +144,8 @@ void Stats<T>::update( T const& data, double weight )
     }
     else
     {
-	min_ = base::min_el(min_, data);
-	max_ = base::max_el(max_, data);
+	min_ = numeric::min_el(min_, data);
+	max_ = numeric::max_el(max_, data);
     }
 
     //
@@ -184,7 +184,7 @@ inline typename Stats<T>::SquareType  Stats<T>::var() const
 }
 
 template <>
-inline Stats<VectorXd>::SquareType Stats<VectorXd>::var() const
+inline Stats<base::VectorXd>::SquareType Stats<base::VectorXd>::var() const
 {
     return ( sum_weight_ > 0.0 ) ? SquareType(M2_ / (sum_weight_ - ddof_)) :
         base::MatrixXd::Zero(M2_.rows(),M2_.cols());
@@ -320,7 +320,10 @@ public:
 
 };
 
+} // namespace numeric
 
-} // namespace base
+#ifndef NUMERIC_DEPRECATE
+#include <numeric/backwards/Stats.hpp>
+#endif
 
 #endif

--- a/src/backwards/Histogram.hpp
+++ b/src/backwards/Histogram.hpp
@@ -1,0 +1,21 @@
+#ifndef __NUMERIC_BACKWARDS_HISTOGRAM_HPP__
+#define __NUMERIC_BACKWARDS_HISTOGRAM_HPP__
+
+#warning "Usage of base::Buckets is deprecated.\
+It will be removed in future releases. \
+Adapt/Rename to numeric::Buckets instead. \
+After adoptation you can disable the warning \
+by building this package with -DNUMERIC_DEPRECATE=1"
+
+#warning "Usage of base::Histogram is deprecated. \
+It will be removed in future releases. \
+Adapt/Rename to numeric::Histogram instead. \
+After adaptation you can disable the warning \
+by building this package with -DNUMERIC_DEPRECATE=1"
+
+namespace base
+{
+    using numeric::Buckets;
+    using numeric::Histogram;
+}
+#endif

--- a/src/backwards/PlaneFitting.hpp
+++ b/src/backwards/PlaneFitting.hpp
@@ -1,0 +1,14 @@
+#ifndef __NUMERIC_BACKWARDS_PLANEFITTING_HPP__
+#define __NUMERIC_BACKWARDS_PLANEFITTING_HPP__
+
+#warning "Usage of base::PlaneFitting is deprecated. \
+It will be removed in future releases. \
+Adapt/Rename to numeric::PlaneFitting instead. \
+After adaptation you can disable the warning \
+by building this package with -DNUMERIC_DEPRECATE=1"
+
+namespace base
+{
+    using numeric::PlaneFitting;
+}
+#endif

--- a/src/backwards/Stats.hpp
+++ b/src/backwards/Stats.hpp
@@ -1,0 +1,19 @@
+#ifndef __NUMERIC_BACKWARDS_STATS_HPP__
+#define __NUMERIC_BACKWARDS_STATS_HPP__
+
+#warning "Usage of base::Square, base::Zero, base::min_el, base::max_el, base::Stats and base::SeriesStats is deprecated. \
+It will be removed in future releases. \
+Adapt/Rename namespace base:: to numeric:: instead. \
+After adaptation you can disable the warning \
+by building this package with -DNUMERIC_DEPRECATE=1"
+
+namespace base
+{
+    using numeric::Square;
+    using numeric::Zero;
+    using numeric::min_el;
+    using numeric::max_el;
+    using numeric::Stats;
+    using numeric::SeriesStats;
+} // namespace base
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 rock_testsuite(
-    unit_test test.cpp
+    unit_test suite.cpp
+        test.cpp
+        numeric.cpp
     DEPS_PKGCONFIG base-types)
 
 #do not build this test if gsl is not installed 

--- a/test/numeric.cpp
+++ b/test/numeric.cpp
@@ -1,14 +1,16 @@
+#define NUMERIC_DEPRECATE 1
 #include <boost/test/unit_test.hpp>
 #include <numeric/Stats.hpp>
 #include <numeric/Histogram.hpp>
 #include <numeric/MatchTemplate.hpp>
 #include <numeric/PlaneFitting.hpp>
 
-#ifndef NUMERIC_DEPRECATE
+BOOST_AUTO_TEST_SUITE(numeric)
+
 BOOST_AUTO_TEST_CASE( stats_test )
 {
     // singular value statistics
-    base::Stats<double> sv;
+    numeric::Stats<double> sv;
     sv.update( 1.0 );
     sv.update( 2.0 );
     sv.update( 3.0 );
@@ -19,7 +21,7 @@ BOOST_AUTO_TEST_CASE( stats_test )
     BOOST_CHECK_EQUAL( sv.max(), 3.0 );
 
     // specialisations for eigen
-    base::Stats< Eigen::Vector2d > mv;
+    numeric::Stats< Eigen::Vector2d > mv;
     mv.update( Eigen::Vector2d(0,1) );
     mv.update( Eigen::Vector2d(1,1) );
 
@@ -32,7 +34,7 @@ BOOST_AUTO_TEST_CASE( stats_test )
     // TODO
 
     // test base::VectorXd
-    base::Stats <base::VectorXd> xv;
+    numeric::Stats <base::VectorXd> xv;
     base::MatrixXd x_data(2,3);
     x_data << 0.0, -1.0, 1.0, 1.0, 0.0, 1.0;
     xv.update(x_data.col(0));
@@ -71,7 +73,7 @@ BOOST_AUTO_TEST_CASE( stats_test )
     s_min << -1.0, 0.0, -2.0, -3.0;
     s_max <<  1.0, 1.0,  1.0,  2.0;
 
-    base::SeriesStats msta(s_data, ddof);
+    numeric::SeriesStats msta(s_data, ddof);
 
     BOOST_CHECK( msta.n() == 3 );
     BOOST_CHECK( msta.min().isApprox(s_min) );
@@ -90,7 +92,7 @@ BOOST_AUTO_TEST_CASE( stats_test )
               0.600, -1.755,  5.970,  7.125,
               0.075, -2.700,  7.125,  9.750;
 
-    base::SeriesStats mwsta(s_data, sw_weights, ddof);
+    numeric::SeriesStats mwsta(s_data, sw_weights, ddof);
 
     BOOST_CHECK( mwsta.mean().isApprox(sw_mean) );
     BOOST_CHECK( mwsta.var().isApprox(sw_var) );
@@ -98,7 +100,7 @@ BOOST_AUTO_TEST_CASE( stats_test )
 
 BOOST_AUTO_TEST_CASE( histogram_test )
 {
-    base::Histogram h( 10, 0.0, 10.0 );
+    numeric::Histogram h( 10, 0.0, 10.0 );
 
     BOOST_CHECK_CLOSE( h.getLowerBound( 0 ), 0, 1e-6 );
     BOOST_CHECK_CLOSE( h.getUpperBound( 0 ), 1.0, 1e-6 );
@@ -119,7 +121,7 @@ BOOST_AUTO_TEST_CASE( histogram_test )
 BOOST_AUTO_TEST_CASE( planefitting_test )
 {
     // fully specified on xy plane
-    base::PlaneFitting<float> pf;
+    numeric::PlaneFitting<float> pf;
     pf.update( Eigen::Vector3f( 0.0, 0, -1.0 ) );
     pf.update( Eigen::Vector3f( 1.0, 0, -1.0 ) );
     pf.update( Eigen::Vector3f( 0.0, 1.0, -1.0 ) );
@@ -163,7 +165,7 @@ BOOST_AUTO_TEST_CASE( planefitting_test )
     pf.clear();
     pf.update( Eigen::Vector3f( 0.0, 0, -1.0 ), 0.5 );
     pf.update( Eigen::Vector3f( 0.0, 0, 1.0 ), 0.5 );
-    base::PlaneFitting<float>::Result res = pf.solve();
+    numeric::PlaneFitting<float>::Result res = pf.solve();
 
     BOOST_CHECK_CLOSE( res.getCovariance()(2,2), 1.0, 1e-4 );
     }
@@ -336,4 +338,5 @@ BOOST_AUTO_TEST_CASE(test_join_vectors)
   BOOST_CHECK_EQUAL(result.size(),result2.size());
   BOOST_CHECK_EQUAL(true,std::equal(result.begin(),result.end(),result2.begin()));
 }
-#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,0 +1,6 @@
+//Do NOT add anything to this file
+// This header from boost takes ages to compile, so we make sure it is
+// compiled
+// only once (here)
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This commit allows to deprecate classes from numeric in the namespace base.
Deprecated classes can be removed by compiling with -DNUMERIC_DEPRECATE=1

Testing has been done with unit_tests and compiling slam/envire and running corresponding unit_tests there.
