### PR TITLE
Add missing include

### DIFF
--- a/src/Circle.cpp
+++ b/src/Circle.cpp
@@ -1,4 +1,5 @@
 #include "Circle.hpp"
+#include <stdexcept>
 
 using namespace numeric;
     


### PR DESCRIPTION
This fixes the following error:

    error: 'runtime_error' is not a member of 'std'