### PR TITLE
Rely on std::foreach when available

### DIFF
--- a/src/Combinatorics.hpp
+++ b/src/Combinatorics.hpp
@@ -12,7 +12,6 @@
 #include <base-logging/Logging.hpp>
 
 #include <iostream>
-#include <boost/foreach.hpp>
 #include <numeric/Twiddle.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 


### PR DESCRIPTION
Using boost/foreach requires -fext-numeric-literals which is required for BOOST_MATH_BIG_CONSTANT
This option is default off in c++11 standard https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
But since we do not need boost foreach with c++11 just remove.