### PR TITLE
Fix deprecated usage of providing project name to `rock_init` macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
+project(numeric VERSION 0.1)
 find_package(Rock)
-rock_init(numeric 0.1)
+rock_init()
 rock_standard_layout()


### PR DESCRIPTION
Fixes this warning:
```
  Passing project name and version to rock_init was a misfeature of Rock's
  macros since CMake 3.0.  You must call CMake's project() at toplevel, like
  this:

  project(numeric VERSION 0.1 DESCRIPTION "project description")

  Remove the arguments to rock_init() to silence this warning
```