### PR TITLE
Remove deprecated and useless `register` keyword

### DIFF
--- a/src/Twiddle.cpp
+++ b/src/Twiddle.cpp
@@ -20,7 +20,7 @@ bool Twiddle::isActivePosition(size_t position) const
 
 bool Twiddle::next()
 {
-  register int i, j, k;
+  int i, j, k;
   j = 1;
   while(p[j] <= 0)
     j++;


### PR DESCRIPTION
Simple fix to get rid of a warning